### PR TITLE
Expose Ports, Output Dockerfile without building the image (dry run)

### DIFF
--- a/DockerfileTemplate.cs
+++ b/DockerfileTemplate.cs
@@ -1,14 +1,21 @@
-﻿namespace Brthor.Dockerize
+﻿using System.Linq;
+
+// ReSharper disable once CheckNamespace
+namespace Brthor.Dockerize
 {
     public static class DockerfileTemplate
     {
         public static string Generate(DockerizeConfiguration config, string outputBinaryName)
         {
-            var addUser = config.Username == null 
+            var addUser = string.IsNullOrWhiteSpace(config.Username)
                 ? ""
                 : $@"RUN groupadd -r {config.Username} && useradd --no-log-init -r -g {config.Username} {config.Username}
 RUN chown {config.Username}:{config.Username} /projectBinaries
 USER {config.Username}:{config.Username}";
+
+            var ports = config.ExposedPorts == null
+                ? ""
+                : string.Join("\n", config.ExposedPorts.Select(port => $"EXPOSE {port}"));
 
             var chownOnAdd = config.Username == null
                 ? ""
@@ -21,6 +28,8 @@ RUN mkdir /projectBinaries
 {addUser}
 ADD {chownOnAdd}./publish/ /projectBinaries/
 WORKDIR /projectBinaries/
+
+{ports}
 
 CMD /projectBinaries/{outputBinaryName}
 ";

--- a/DockerizeConfiguration.cs
+++ b/DockerizeConfiguration.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.DotNet.Cli.Utils;
+﻿using System.Collections.Generic;
+using Microsoft.DotNet.Cli.Utils;
 
+// ReSharper disable once CheckNamespace
 namespace Brthor.Dockerize
 {
     public class DockerizeConfiguration
@@ -22,22 +24,36 @@ namespace Brthor.Dockerize
         public string BuildConfiguration { get; }
         
         public string Username { get; }
+        
+        public List<string> ExposedPorts { get; }
+        
+        public bool DryRun { get; }
 
-        public DockerizeConfiguration(string projectName, string configuration, string tag, string baseRid, string baseImage, 
-            string username=null)
+        public DockerizeConfiguration(
+            string projectName, 
+            string configuration, 
+            string tag, 
+            string baseRid, 
+            string baseImage, 
+            bool dryRun,
+            string username, 
+            List<string> exposedPorts)
         {
             GeneratedImageTag = tag ?? projectName;
             BaseRid = baseRid ?? "linux-x64";
             BaseImage = baseImage ?? "microsoft/dotnet:2.0-runtime";
             BuildConfiguration = configuration ?? "Release";
+            
+            DryRun = dryRun;
             Username = username;
+            ExposedPorts = exposedPorts;
             
             Reporter.Output.WriteLine($"Dockerize.NET".Blue());
             Reporter.Output.WriteLine("Base Docker Image: ".White() +  $"{BaseImage}".Green());
             Reporter.Output.WriteLine("Base Rid of Docker Image: ".White() + $"{BaseRid}".Green());
             Reporter.Output.WriteLine("Tag: ".White() + $"{GeneratedImageTag}".Green());
             
-            if (Username != null)
+            if (!string.IsNullOrWhiteSpace(Username))
                 Reporter.Output.WriteLine("Username: ".White() + $"{Username}".Green());
         }
     }


### PR DESCRIPTION
Expose Ports, Output Dockerfile without building the image (dry run)

Adds `-p, --port` and `-n, --dry-run`